### PR TITLE
fix: removed language hardcoded in getContext call

### DIFF
--- a/melcloud.js
+++ b/melcloud.js
@@ -45,7 +45,7 @@ class Melcloud {
             var postData = {
                 "Email":this.user,
                 "Password":this.password,
-                "Language":7,
+                // "Language":7,
                 "AppVersion":"1.32.1.0",
                 "Persist":true,
                 "CaptchaResponse":null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "node-red-contrib-melcloud",
-    "version" : "1.6.0",
+    "version" : "1.6.1",
     "description" : "Node-RED node to interface with Mitsubishi Air Conditioning Device with MELCloud API",
     "dependencies": {
       "https" : "^1.0.0",


### PR DESCRIPTION
French language is harcoded again in the getContext call.
This issue was solved in the past https://github.com/ysimonx/node-red-contrib-melcloud/issues/2
And is happening again.